### PR TITLE
MULE-12903: Every exported Mule package must contain api (part2)

### DIFF
--- a/src/test/java/org/mule/extension/validation/BasicValidationTestCase.java
+++ b/src/test/java/org/mule/extension/validation/BasicValidationTestCase.java
@@ -29,7 +29,7 @@ import org.mule.extension.validation.api.Validator;
 import org.mule.functional.junit4.FlowRunner;
 import org.mule.mvel2.compiler.BlankLiteral;
 import org.mule.runtime.api.message.Error;
-import org.mule.runtime.core.exception.MessagingException;
+import org.mule.runtime.core.api.exception.MessagingException;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/test/java/org/mule/extension/validation/ValidationTestCase.java
+++ b/src/test/java/org/mule/extension/validation/ValidationTestCase.java
@@ -17,8 +17,7 @@ import org.mule.functional.junit4.FlowRunner;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.runtime.api.i18n.I18nMessage;
 import org.mule.runtime.api.message.Error;
-import org.mule.runtime.core.exception.MessagingException;
-import org.mule.runtime.core.exception.TypedException;
+import org.mule.runtime.core.api.exception.MessagingException;
 import org.mule.test.runner.ArtifactClassLoaderRunnerConfig;
 
 @ArtifactClassLoaderRunnerConfig(exportPluginClasses = {ValidationMessages.class})


### PR DESCRIPTION
MULE-10370: Remove custom-exception-strategy element

_ Moving classes from org.mule.runtime.core.extension to api/internal
_ Temporarily exporting org.mule.runtime.core.internal.extension (because MULE-12427)
_ Adding test:exception-strategy for tests to replace mule:custom-exception-strategy
_ Removing mule:custom-exception-strategy element