### PR TITLE
MULE-12327: ArtifactClassLoaderRunner - Application URLs are also

### DIFF
--- a/src/test/java/org/mule/extension/validation/BasicValidationTestCase.java
+++ b/src/test/java/org/mule/extension/validation/BasicValidationTestCase.java
@@ -26,7 +26,7 @@ import org.mule.extension.validation.api.MultipleValidationException;
 import org.mule.extension.validation.api.MultipleValidationResult;
 import org.mule.extension.validation.api.ValidationResult;
 import org.mule.extension.validation.api.Validator;
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.mvel2.compiler.BlankLiteral;
 import org.mule.runtime.api.message.Error;
 import org.mule.runtime.core.api.exception.MessagingException;

--- a/src/test/java/org/mule/extension/validation/NumberValidationTestCase.java
+++ b/src/test/java/org/mule/extension/validation/NumberValidationTestCase.java
@@ -10,7 +10,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeThat;
 import org.mule.extension.validation.api.NumberType;
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.test.runner.RunnerDelegateTo;
 
 import java.util.Arrays;

--- a/src/test/java/org/mule/extension/validation/ValidationTestCase.java
+++ b/src/test/java/org/mule/extension/validation/ValidationTestCase.java
@@ -13,7 +13,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 import org.mule.extension.validation.api.ValidationException;
 import org.mule.extension.validation.internal.ValidationMessages;
-import org.mule.functional.junit4.FlowRunner;
+import org.mule.functional.api.flow.FlowRunner;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 import org.mule.runtime.api.i18n.I18nMessage;
 import org.mule.runtime.api.message.Error;


### PR DESCRIPTION
including transitive dependencies from filter ones
* Cleanup test artifact dependencies so no unwanted transitive
dependencies end up in the APP classloader for tests
* Refactor flowRunner so that test artifact doesn't bring its transitive
dependencies