### PR TITLE
MULE-13545: Cleanup core API

### DIFF
--- a/src/main/java/org/mule/extension/validation/api/ValidationException.java
+++ b/src/main/java/org/mule/extension/validation/api/ValidationException.java
@@ -23,7 +23,7 @@ import org.mule.runtime.extension.api.exception.ModuleException;
  *
  * @since 3.7.0
  */
-// TODO MULE-12397 merge this with org.mule.runtime.core.api.routing.ValidationException
+// TODO MULE-12397 merge this with org.mule.runtime.core.internal.routing.ValidationException
 public class ValidationException extends ModuleException implements ErrorMessageAwareException {
 
   private static final long serialVersionUID = -7191589190396052480L;


### PR DESCRIPTION
_ Moving classes out of core's api package
_ When possible, classes where moved to internal
_ Moved to privileged when classes where required on compatibility
_ Moved to other module's API when needed on tests or it made sense
_ Deleted if not needed anymore
_ Some tests were ignored as they use an internal class and need refactoring