### PR TITLE
MULE-16066: It's not possible to serialize validation result

### DIFF
--- a/src/main/java/org/mule/extension/validation/api/ValidationResult.java
+++ b/src/main/java/org/mule/extension/validation/api/ValidationResult.java
@@ -6,13 +6,15 @@
  */
 package org.mule.extension.validation.api;
 
+import java.io.Serializable;
+
 /**
  * The result of a validation
  *
  * @see Validator
  * @since 1.0
  */
-public interface ValidationResult {
+public interface ValidationResult extends Serializable {
 
   /**
    * Returns a message associated with the execution of the validation. If the validation failed (which means that


### PR DESCRIPTION
If merged this PR, it makes ValidationResult Serializable, allowing to be stored on
object store.