### PR TITLE
fix/VAL-24: Remove local packages that are exported by the runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
                     <groupId>commons-beanutils</groupId>
                     <artifactId>commons-beanutils</artifactId>
                 </exclusion>
+                <!--exported by runtime-->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -57,11 +62,25 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guavaVersion}</version>
+            <exclusions>
+                <!--exported by runtime, findbugs exports javax.annotations - see: https://github.com/google/guava/issues/2960-->
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-core</artifactId>
             <version>${projectReactorVersion}</version>
+            <exclusions>
+                <!--exported by runtime-->
+                <exclusion>
+                    <groupId>org.reactivestreams</groupId>
+                    <artifactId>reactive-streams</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,13 +51,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commonsLangVersion}</version>
         </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -83,6 +81,7 @@
             </exclusions>
         </dependency>
 
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.mule.modules</groupId>
             <artifactId>mule-spring-test-plugin</artifactId>


### PR DESCRIPTION
fix result with JDK11: https://jenkins-onprem.build.msap.io/blue/organizations/jenkins/Mule-runtime%2Fextensions%2Fmule-validation-module/detail/fix%2FVAL-24-JDK11/4/tests (branch: [VAL-24-JDK11](https://github.com/mulesoft/mule-validation-module/tree/fix/VAL-24-JDK11))
