### PR TITLE
W-12130090 - Control Multiple Erros

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-validation-module</artifactId>
     <packaging>mule-extension</packaging>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.0.3-SNAPSHOT</version>
     <name>Validations Module</name>
     <description>A Mule extension that provides functionality for performing validations</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,7 @@
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-validation-module</artifactId>
     <packaging>mule-extension</packaging>
-    <version>3.0.0-SNAPSHOT</version>
-
+    <version>2.1.0-SNAPSHOT</version>
     <name>Validations Module</name>
     <description>A Mule extension that provides functionality for performing validations</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-validation-module</artifactId>
     <packaging>mule-extension</packaging>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>Validations Module</name>
     <description>A Mule extension that provides functionality for performing validations</description>
 

--- a/src/main/java/org/mule/extension/validation/internal/privileged/AggregateOperationExecutor.java
+++ b/src/main/java/org/mule/extension/validation/internal/privileged/AggregateOperationExecutor.java
@@ -72,12 +72,8 @@ abstract class AggregateOperationExecutor implements CompletableComponentExecuto
         childContext.error(e);
         Error error =
             e.getEvent().getError().orElse(null);
-        if (error != null && isValidation(error.getErrorType())) {
+        if (error != null) {
           errors.add(error);
-        } else {
-          // propagated error must have its event tied to the context of the originally passed event, not a child
-          callback.error(new EventProcessingException(CoreEvent.builder(event.getContext(), event).error(error).build(),
-                                                      e.getCause()));
         }
       } catch (Exception e) {
         childContext.error(e);

--- a/src/test/java/org/mule/extension/validation/AggregateValidationTestCase.java
+++ b/src/test/java/org/mule/extension/validation/AggregateValidationTestCase.java
@@ -26,6 +26,7 @@ public class AggregateValidationTestCase extends ValidationTestCase {
   private static final String EMAIL_VALIDATION_FLOW = "email";
   private static final String VALIDATION_NAMESPACE = "VALIDATION";
   private static final String MULTIPLE_ERROR = "MULTIPLE";
+  private static final String MULE_NAMESPACE = "MULE";
 
   @Rule
   public ExpectedError expected = ExpectedError.none();
@@ -54,13 +55,13 @@ public class AggregateValidationTestCase extends ValidationTestCase {
 
   @Test
   public void nonValidationErrorInsideAll() throws Exception {
-    expected.expectErrorType("MULE", EXPRESSION.getType());
+    expected.expectErrorType(MULE_NAMESPACE, EXPRESSION.getType());
     configureGetAllRunner(flowRunner("allWithNonValidationError"), VALID_EMAIL, VALID_URL).run();
   }
 
   @Test
   public void nonValidationErrorMixedWithValidationErrorsInsideAll() throws Exception {
-    expected.expectErrorType("MULE", EXPRESSION.getType());
+    expected.expectErrorType(MULE_NAMESPACE, EXPRESSION.getType());
     configureGetAllRunner(flowRunner("allWithNonValidationError"), INVALID_EMAIL, INVALID_URL).run();
   }
 
@@ -92,13 +93,13 @@ public class AggregateValidationTestCase extends ValidationTestCase {
 
   @Test
   public void nonValidationErrorInsideAny() throws Exception {
-    expected.expectErrorType("MULE", EXPRESSION.getType());
+    expected.expectErrorType(MULE_NAMESPACE, EXPRESSION.getType());
     configureGetAllRunner(flowRunner("anyWithNonValidationError"), VALID_EMAIL, VALID_URL).run();
   }
 
   @Test
   public void nonValidationErrorMixedWithValidationErrorsInsideAny() throws Exception {
-    expected.expectErrorType("MULE", EXPRESSION.getType());
+    expected.expectErrorType(MULE_NAMESPACE, EXPRESSION.getType());
     configureGetAllRunner(flowRunner("anyWithNonValidationError"), INVALID_EMAIL, INVALID_URL).run();
   }
 

--- a/src/test/java/org/mule/extension/validation/AggregateValidationTestCase.java
+++ b/src/test/java/org/mule/extension/validation/AggregateValidationTestCase.java
@@ -54,7 +54,7 @@ public class AggregateValidationTestCase extends ValidationTestCase {
 
   @Test
   public void nonValidationErrorInsideAll() throws Exception {
-    expected.expectErrorType("MULE", EXPRESSION.getType());
+    expected.expectErrorType(VALIDATION_NAMESPACE, MULTIPLE_ERROR);
     configureGetAllRunner(flowRunner("allWithNonValidationError"), VALID_EMAIL, VALID_URL).run();
   }
 
@@ -92,13 +92,15 @@ public class AggregateValidationTestCase extends ValidationTestCase {
 
   @Test
   public void nonValidationErrorInsideAny() throws Exception {
-    expected.expectErrorType("MULE", EXPRESSION.getType());
-    configureGetAllRunner(flowRunner("anyWithNonValidationError"), VALID_EMAIL, VALID_URL).run();
+    FlowRunner runner = configureGetAllRunner(flowRunner("anyWithNonValidationError"), VALID_EMAIL, VALID_URL);
+
+    assertThat(runner.buildEvent().getMessage().getPayload().getValue(),
+               is(sameInstance(runner.run().getMessage().getPayload().getValue())));
   }
 
   @Test
   public void nonValidationErrorMixedWithValidationErrorsInsideAny() throws Exception {
-    expected.expectErrorType("MULE", EXPRESSION.getType());
+    expected.expectErrorType(VALIDATION_NAMESPACE, MULTIPLE_ERROR);
     configureGetAllRunner(flowRunner("anyWithNonValidationError"), INVALID_EMAIL, INVALID_URL).run();
   }
 

--- a/src/test/java/org/mule/extension/validation/AggregateValidationTestCase.java
+++ b/src/test/java/org/mule/extension/validation/AggregateValidationTestCase.java
@@ -54,13 +54,13 @@ public class AggregateValidationTestCase extends ValidationTestCase {
 
   @Test
   public void nonValidationErrorInsideAll() throws Exception {
-    expected.expectErrorType(VALIDATION_NAMESPACE, MULTIPLE_ERROR);
+    expected.expectErrorType("MULE", EXPRESSION.getType());
     configureGetAllRunner(flowRunner("allWithNonValidationError"), VALID_EMAIL, VALID_URL).run();
   }
 
   @Test
   public void nonValidationErrorMixedWithValidationErrorsInsideAll() throws Exception {
-    expected.expectErrorType(VALIDATION_NAMESPACE, MULTIPLE_ERROR);
+    expected.expectErrorType("MULE", EXPRESSION.getType());
     configureGetAllRunner(flowRunner("allWithNonValidationError"), INVALID_EMAIL, INVALID_URL).run();
   }
 
@@ -92,15 +92,13 @@ public class AggregateValidationTestCase extends ValidationTestCase {
 
   @Test
   public void nonValidationErrorInsideAny() throws Exception {
-    FlowRunner runner = configureGetAllRunner(flowRunner("anyWithNonValidationError"), VALID_EMAIL, VALID_URL);
-
-    assertThat(runner.buildEvent().getMessage().getPayload().getValue(),
-               is(sameInstance(runner.run().getMessage().getPayload().getValue())));
+    expected.expectErrorType("MULE", EXPRESSION.getType());
+    configureGetAllRunner(flowRunner("anyWithNonValidationError"), VALID_EMAIL, VALID_URL).run();
   }
 
   @Test
   public void nonValidationErrorMixedWithValidationErrorsInsideAny() throws Exception {
-    expected.expectErrorType(VALIDATION_NAMESPACE, MULTIPLE_ERROR);
+    expected.expectErrorType("MULE", EXPRESSION.getType());
     configureGetAllRunner(flowRunner("anyWithNonValidationError"), INVALID_EMAIL, INVALID_URL).run();
   }
 

--- a/src/test/munit/all-validation-test-suite.xml
+++ b/src/test/munit/all-validation-test-suite.xml
@@ -47,12 +47,12 @@
         <munit:execution>
             <try>
                 <validation:all>
-                    <validation:is-not-null value="#[null]">
-                        <error-mapping sourceType="VALIDATION:NULL" targetType="TEST:NULL" />
+                         <error-mapping sourceType="VALIDATION:MULTIPLE" targetType="TEST:MULTIPLE" />
+                        <validation:is-not-null value="#[null]">
                     </validation:is-not-null>
                 </validation:all>
                 <error-handler>
-                    <on-error-continue type="TEST:NULL">
+                    <on-error-continue type="TEST:MULTIPLE">
                         <munit-tools:queue/>
                     </on-error-continue>
                 </error-handler>

--- a/src/test/munit/all-validation-test-suite.xml
+++ b/src/test/munit/all-validation-test-suite.xml
@@ -47,12 +47,12 @@
         <munit:execution>
             <try>
                 <validation:all>
-                         <error-mapping sourceType="VALIDATION:MULTIPLE" targetType="TEST:MULTIPLE" />
-                        <validation:is-not-null value="#[null]">
+                    <validation:is-not-null value="#[null]">
+                        <error-mapping sourceType="VALIDATION:NULL" targetType="TEST:NULL" />
                     </validation:is-not-null>
                 </validation:all>
                 <error-handler>
-                    <on-error-continue type="TEST:MULTIPLE">
+                    <on-error-continue type="TEST:NULL">
                         <munit-tools:queue/>
                     </on-error-continue>
                 </error-handler>


### PR DESCRIPTION
_Hi, thank you for your work. We understand that you want to merge your changes and move on from this issue, but we also want to maintain the safety, readability, and testability of our code. Because of this, we kindly ask that you confirm that you have fulfilled the prerequisites for each category of activity before merging your changes._

### For ALL the Releases:

- [x] There is a task in GUS for this change.
- [x] The corresponding Release Notes have been written and shared with the documentation team.
- [x] The new code has tests and they have before and after methods to be sure that you are working with a clean environment and that you are leaving the environment clean after they finish.
- [x] If you are using reflection, create a test to call the methods you are invoking, this way, if there is a change in the API, the test will be able to detect it.
- [x] If the project has a parent pom and modules, the release pipeline only uploads the modules, so, please, make sure that the parent was deployed in the repositories before considering this release finished.
- [ ] Notify in the Slack Channel that the release is complete, so the Docs team can merge the Documentation and Release Notes PR. The docs team always checks in Anypoint Exchange that the connector is released before merging the release notes.
- [ ] Add the connector build to GUS, and assign that build to the GUS ticket.
- [x] Create a change case request, based on the Change Case Management doc https://docs.google.com/document/d/1tMJlTTZLaXMLiYwxlMBFY1yJwBmejhc4-IP8HAXgDfY/edit#

### Patch Version:

- [x] The Pull Request has been peer-reviewed.
- [x] No backward compatibility is broken.
- [x] Documentation: (Required) Release Notes PR with compatibility table. Share it with the Docs team.

**NOTE**: _(applies only for Core-Connectors connectors and modules) The release process ends when you merge the pull request that updates the support branch to the new snapshot, please don't forget to do this._
